### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,2 +1,0 @@
-metagovernment.org
-


### PR DESCRIPTION
The CNAME file causes the page to open the metagovernment page rather than this one. Removing it should allow viewing the content.